### PR TITLE
[bugfix] Remove ambiguous overload of abs in divide_by_i

### DIFF
--- a/vectori128.h
+++ b/vectori128.h
@@ -6640,7 +6640,7 @@ static inline Vec4i divide_by_i(Vec4i const x) {
         // d1 is a power of 2. use shift
         constexpr int k = bit_scan_reverse_const(d1);
         __m128i sign;
-        if (k > 1) sign = _mm_srai_epi32(x, abs(k-1)); else sign = x;// k copies of sign bit
+        if (k > 1) sign = _mm_srai_epi32(x, k-1); else sign = x;// k copies of sign bit
         __m128i bias = _mm_srli_epi32(sign, 32 - k);       // bias = x >= 0 ? 0 : k-1
         __m128i xpbias = _mm_add_epi32(x, bias);           // x + bias
         __m128i q = _mm_srai_epi32(xpbias, k);             // (x + bias) >> k
@@ -6766,7 +6766,7 @@ static inline Vec8s divide_by_i(Vec8s const x) {
         // d is a power of 2. use shift
         const int k = bit_scan_reverse_const(uint32_t(d1));
         __m128i sign;
-        if (k > 1) sign = _mm_srai_epi16(x, abs(k-1)); else sign = x;// k copies of sign bit
+        if (k > 1) sign = _mm_srai_epi16(x, k-1); else sign = x;// k copies of sign bit
         __m128i bias = _mm_srli_epi16(sign, 16 - k);       // bias = x >= 0 ? 0 : k-1
         __m128i xpbias = _mm_add_epi16(x, bias);           // x + bias
         __m128i q = _mm_srai_epi16(xpbias, k);             // (x + bias) >> k

--- a/vectori128.h
+++ b/vectori128.h
@@ -6640,7 +6640,7 @@ static inline Vec4i divide_by_i(Vec4i const x) {
         // d1 is a power of 2. use shift
         constexpr int k = bit_scan_reverse_const(d1);
         __m128i sign;
-        if (k > 1) sign = _mm_srai_epi32(x, k-1); else sign = x;// k copies of sign bit
+        if constexpr (k > 1) sign = _mm_srai_epi32(x, k-1); else sign = x;// k copies of sign bit
         __m128i bias = _mm_srli_epi32(sign, 32 - k);       // bias = x >= 0 ? 0 : k-1
         __m128i xpbias = _mm_add_epi32(x, bias);           // x + bias
         __m128i q = _mm_srai_epi32(xpbias, k);             // (x + bias) >> k
@@ -6764,9 +6764,9 @@ static inline Vec8s divide_by_i(Vec8s const x) {
     const uint32_t d1 = d > 0 ? uint32_t(d) : uint32_t(-d);// compile-time abs(d). (force GCC compiler to treat d as 32 bits, not 64 bits)
     if constexpr ((d1 & (d1 - 1)) == 0) {
         // d is a power of 2. use shift
-        const int k = bit_scan_reverse_const(uint32_t(d1));
+        constexpr int k = bit_scan_reverse_const(uint32_t(d1));
         __m128i sign;
-        if (k > 1) sign = _mm_srai_epi16(x, k-1); else sign = x;// k copies of sign bit
+        if constexpr (k > 1) sign = _mm_srai_epi16(x, k-1); else sign = x;// k copies of sign bit
         __m128i bias = _mm_srli_epi16(sign, 16 - k);       // bias = x >= 0 ? 0 : k-1
         __m128i xpbias = _mm_add_epi16(x, bias);           // x + bias
         __m128i q = _mm_srai_epi16(xpbias, k);             // (x + bias) >> k

--- a/vectori256.h
+++ b/vectori256.h
@@ -5408,7 +5408,7 @@ static inline Vec8i divide_by_i(Vec8i const x) {
         // d1 is a power of 2. use shift
         constexpr int k = bit_scan_reverse_const(d1);
         __m256i sign;
-        if (k > 1) sign = _mm256_srai_epi32(x, k-1); else sign = x;  // k copies of sign bit
+        if constexpr (k > 1) sign = _mm256_srai_epi32(x, k-1); else sign = x;  // k copies of sign bit
         __m256i bias    = _mm256_srli_epi32(sign, 32-k);   // bias = x >= 0 ? 0 : k-1
         __m256i xpbias  = _mm256_add_epi32 (x, bias);      // x + bias
         __m256i q       = _mm256_srai_epi32(xpbias, k);    // (x + bias) >> k

--- a/vectori256.h
+++ b/vectori256.h
@@ -5408,7 +5408,7 @@ static inline Vec8i divide_by_i(Vec8i const x) {
         // d1 is a power of 2. use shift
         constexpr int k = bit_scan_reverse_const(d1);
         __m256i sign;
-        if (k > 1) sign = _mm256_srai_epi32(x, abs(k-1)); else sign = x;  // k copies of sign bit
+        if (k > 1) sign = _mm256_srai_epi32(x, k-1); else sign = x;  // k copies of sign bit
         __m256i bias    = _mm256_srli_epi32(sign, 32-k);   // bias = x >= 0 ? 0 : k-1
         __m256i xpbias  = _mm256_add_epi32 (x, bias);      // x + bias
         __m256i q       = _mm256_srai_epi32(xpbias, k);    // (x + bias) >> k
@@ -5527,7 +5527,7 @@ static inline Vec16s divide_by_i(Vec16s const x) {
         // d is a power of 2. use shift
         constexpr int k = bit_scan_reverse_const(uint32_t(d1));
         __m256i sign;
-        if constexpr (k > 1) sign = _mm256_srai_epi16(x, abs(k-1)); else sign = x;// k copies of sign bit
+        if constexpr (k > 1) sign = _mm256_srai_epi16(x, k-1); else sign = x;// k copies of sign bit
         __m256i bias    = _mm256_srli_epi16(sign, 16-k);   // bias = x >= 0 ? 0 : k-1
         __m256i xpbias  = _mm256_add_epi16 (x, bias);      // x + bias
         __m256i q       = _mm256_srai_epi16(xpbias, k);    // (x + bias) >> k

--- a/vectori512.h
+++ b/vectori512.h
@@ -2000,7 +2000,7 @@ static inline Vec16i divide_by_i(Vec16i const x) {
         // d1 is a power of 2. use shift
         constexpr int k = bit_scan_reverse_const(d1);
         __m512i sign;
-        if (k > 1) sign = _mm512_srai_epi32(x, abs(k-1)); else sign = x;  // k copies of sign bit
+        if constexpr (k > 1) sign = _mm512_srai_epi32(x, k-1); else sign = x;  // k copies of sign bit
         __m512i bias    = _mm512_srli_epi32(sign, 32-k);             // bias = x >= 0 ? 0 : k-1
         __m512i xpbias  = _mm512_add_epi32 (x, bias);                // x + bias
         __m512i q       = _mm512_srai_epi32(xpbias, k);              // (x + bias) >> k


### PR DESCRIPTION
The divide_by_i function fails to compile with an ambiguous
overload of the function abs(int). The generic way of fixing
this seems to be to add a `using std::abs` statement that
enables ADL to find the correct overload. In this specific use
case however, the whole abs-call seems to be superfluous as
it checks `abs(k-1)` within a `k>1`-if-clause.
I have therefore removed the abs-call altogether.