### PR TITLE
Remove unused variable warnings

### DIFF
--- a/instrset.h
+++ b/instrset.h
@@ -1042,7 +1042,6 @@ constexpr uint64_t blend_flags(int const (&a)[V::size()]) {
     int ix = 0;                                            // index number i
     const uint32_t nlanes = sizeof(V) / 16;                // number of 128-bit lanes
     const uint32_t lanesize = N / nlanes;                  // elements per lane
-    const uint32_t elementsize = sizeof(V) / N;            // size of each vector element
     uint32_t lane = 0;                                     // current lane
     uint32_t rot = 999;                                    // rotate left count
     int lanepattern[lanesize] = {0};                       // pattern in each lane
@@ -1150,6 +1149,7 @@ constexpr uint64_t blend_flags(int const (&a)[V::size()]) {
             else {
                 r |= blend_rotateab;
             }
+            const uint32_t elementsize = sizeof(V) / N;
             r |= uint64_t((rot & lanesize - 1) * elementsize) << blend_rotpattern;
         }
 #endif

--- a/instrset.h
+++ b/instrset.h
@@ -1,8 +1,8 @@
 /****************************  instrset.h   **********************************
 * Author:        Agner Fog
 * Date created:  2012-05-30
-* Last modified: 2019-08-01
-* Version:       2.00.00
+* Last modified: 2019-08-30
+* Version:       2.00.01
 * Project:       vector class library
 * Description:
 * Header file for various compiler-specific tasks as well as common
@@ -21,7 +21,7 @@
 ******************************************************************************/
 
 #ifndef INSTRSET_H
-#define INSTRSET_H 20000
+#define INSTRSET_H 20001
 
 // Macro to indicate 64 bit mode
 #if (defined(_M_AMD64) || defined(_M_X64) || defined(__amd64) ) && ! defined(__x86_64__)

--- a/vectormath_exp.h
+++ b/vectormath_exp.h
@@ -1,8 +1,8 @@
 /****************************  vectormath_exp.h   ******************************
 * Author:        Agner Fog
 * Date created:  2014-04-18
-* Last modified: 2019-08-01
-* Version:       2.00.00
+* Last modified: 2019-08-30
+* Version:       2.00.01
 * Project:       vector class library
 * Description:
 * Header file containing inline vector functions of logarithms, exponential 

--- a/vectormath_exp.h
+++ b/vectormath_exp.h
@@ -1511,7 +1511,6 @@ static inline VTYPE pow_template_d(VTYPE const x0, VTYPE const y) {
     const double ln2d_hi = 0.693145751953125;           // log(2) in extra precision, high bits
     const double ln2d_lo = 1.42860682030941723212E-6;   // low bits of log(2)
     const double log2e   = VM_LOG2E;                    // 1/log(2)
-    const double pow2_52 = 4503599627370496.0;          // 2^52
 
     // coefficients for Pade polynomials
     const double P0logl =  2.0039553499201281259648E1;
@@ -2214,7 +2213,6 @@ static inline Vec16ui nan_code(Vec16f const x) {
 // This function returns the code hidden in a NAN. The sign bit is ignored
 static inline Vec8uq nan_code(Vec8d const x) {
     Vec8uq a = Vec8uq(reinterpret_i(x));
-    Vec8q const n = 0x000FFFFFFFFFFFFF;
     return select(Vec8qb(is_nan(x)), a << 12 >> (12+29), 0);
 }
 

--- a/vectormath_trig.h
+++ b/vectormath_trig.h
@@ -1,8 +1,8 @@
 /****************************  vectormath_trig.h   ******************************
 * Author:        Agner Fog
 * Date created:  2014-04-18
-* Last modified: 2019-08-01
-* Version:       2.00.00
+* Last modified: 2019-08-30
+* Version:       2.00.01
 * Project:       vector class library
 * Description:
 * Header file containing inline version of trigonometric functions 

--- a/vectormath_trig.h
+++ b/vectormath_trig.h
@@ -47,8 +47,6 @@ template<typename VTYPE, int SC>
 static inline VTYPE sincos_d(VTYPE * cosret, VTYPE const xx) {
 
     // define constants
-    const double ONEOPIO4 = 4. / VM_PI;
-
     const double P0sin = -1.66666666666666307295E-1;
     const double P1sin = 8.33333333332211858878E-3;
     const double P2sin = -1.98412698295895385996E-4;
@@ -319,8 +317,6 @@ template<typename VTYPE>
 static inline VTYPE tan_d(VTYPE const x) {
 
     // define constants
-    const double ONEOPIO4 = 4. / VM_PI;
-
     const double DP1 = 7.853981554508209228515625E-1 * 2.;;
     const double DP2 = 7.94662735614792836714E-9 * 2.;;
     const double DP3 = 3.06161699786838294307E-17 * 2.;;


### PR DESCRIPTION
These hamper the usability of the library with -Wall.
With these changes, my testing suite runs warning-free.