### PR TITLE
Don't use <fmaintrin.h> directly; include <immintrin.h> instead

### DIFF
--- a/instrset.h
+++ b/instrset.h
@@ -130,6 +130,7 @@
 
 // FMA3 instruction set
 #if defined (__FMA__) && (defined(__GNUC__) || defined(__clang__))  && ! defined (__INTEL_COMPILER)
+#include <immintrin.h>
 #include <fmaintrin.h>
 #endif // __FMA__
 


### PR DESCRIPTION
When compiling dispatch_example*.cpp, the compiler emits the following error:

    In file included from external/vectorclass/instrset_detect.cpp:14:
    In file included from external/vectorclass/instrset.h:133:
    /Library/Developer/CommandLineTools/usr/lib/clang/12.0.0/include/fmaintrin.h:11:2: error: "Never use <fmaintrin.h> directly; include <immintrin.h> instead."
    #error "Never use <fmaintrin.h> directly; include <immintrin.h> instead."