### PR TITLE
Fixed elementtype for Vec8uq.

### DIFF
--- a/vectori512.h
+++ b/vectori512.h
@@ -1157,7 +1157,7 @@ public:
         return Vec4uq(Vec8q::get_high());
     }
     static constexpr int elementtype() {
-        return 10;
+        return 11;
     }
 };
 


### PR DESCRIPTION
I’ve tried to program some template code where the correct vector type would be determined from the element type and number.
However, my code failed for `Vec8uq`, as the `Vec8uq::elementtype` was `10`, which denotes `int64_t` (according to the manual), but which should be `11`, which represents `uint64_t`. This is the issue solved by this pull request.